### PR TITLE
Update wp-postviews.php

### DIFF
--- a/wp-postviews.php
+++ b/wp-postviews.php
@@ -218,7 +218,12 @@ if(!function_exists('get_least_viewed')) {
 		$temp = '';
 		$output = '';
 		if(!empty($mode) && $mode != 'both') {
-			$where = "post_type = '$mode'";
+			if(is_array($mode)) {
+				$mode = implode("','",$mode);
+				$where = "post_type IN ('".$mode."')";
+			} else {
+				$where = "post_type = '$mode'";
+			}
 		} else {
 			$where = '1=1';
 		}
@@ -260,7 +265,12 @@ if(!function_exists('get_most_viewed')) {
 		$temp = '';
 		$output = '';
 		if(!empty($mode) && $mode != 'both') {
-			$where = "post_type = '$mode'";
+			if(is_array($mode)) {
+				$mode = implode("','",$mode);
+				$where = "post_type IN ('".$mode."')";
+			} else {
+				$where = "post_type = '$mode'";
+			}
 		} else {
 			$where = '1=1';
 		}
@@ -307,7 +317,12 @@ if(!function_exists('get_least_viewed_category')) {
 			$category_sql = "$wpdb->term_taxonomy.term_id = $category_id";
 		}
 		if(!empty($mode) && $mode != 'both') {
-			$where = "post_type = '$mode'";
+			if(is_array($mode)) {
+				$mode = implode("','",$mode);
+				$where = "post_type IN ('".$mode."')";
+			} else {
+				$where = "post_type = '$mode'";
+			}
 		} else {
 			$where = '1=1';
 		}
@@ -354,7 +369,12 @@ if(!function_exists('get_most_viewed_category')) {
 			$category_sql = "$wpdb->term_taxonomy.term_id = $category_id";
 		}
 		if(!empty($mode) && $mode != 'both') {
-			$where = "post_type = '$mode'";
+			if(is_array($mode)) {
+				$mode = implode("','",$mode);
+				$where = "post_type IN ('".$mode."')";
+			} else {
+				$where = "post_type = '$mode'";
+			}
 		} else {
 			$where = '1=1';
 		}
@@ -401,7 +421,12 @@ if(!function_exists('get_most_viewed_tag')) {
 			$tag_sql = "$wpdb->term_taxonomy.term_id = $tag_id";
 		}
 		if(!empty($mode) && $mode != 'both') {
-			$where = "post_type = '$mode'";
+			if(is_array($mode)) {
+				$mode = implode("','",$mode);
+				$where = "post_type IN ('".$mode."')";
+			} else {
+				$where = "post_type = '$mode'";
+			}
 		} else {
 			$where = '1=1';
 		}
@@ -448,7 +473,12 @@ if(!function_exists('get_least_viewed_tag')) {
 			$tag_sql = "$wpdb->term_taxonomy.term_id = $tag_id";
 		}
 		if(!empty($mode) && $mode != 'both') {
-			$where = "post_type = '$mode'";
+			if(is_array($mode)) {
+				$mode = implode("','",$mode);
+				$where = "post_type IN ('".$mode."')";
+			} else {
+				$where = "post_type = '$mode'";
+			}
 		} else {
 			$where = '1=1';
 		}


### PR DESCRIPTION
All least_viewed and most_viewed functions now accept an array of post types for the $mode variable, as well as the previous options of a single post type value or "both" (all post types).
