### PR TITLE
Add FAQ For compatibility with LiteSpeed Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,18 +271,20 @@ N/A
 1. Use: `<div id="postviews_lscwp"></div>` to replace `<?php if(function_exists('the_views')) { the_views(); } ?>`.
   * NOTE: The id can be changed, but the div id and the ajax function must match.
 2. Replace the ajax query in `wp-content/plugins/wp-postviews/postviews-cache.js` with
-```
-jQuery.ajax({
-    type:"GET",
-    url:viewsCacheL10n.admin_ajax_url,
-    data:"postviews_id="+viewsCacheL10n.post_id+"&action=postviews",
-    cache:!1,
-    success:function(data) {
-        if(data) {
-            jQuery('#postviews_lscwp').html(data+' views');
-        }
-    }
-});
-```
+
+    ```
+    jQuery.ajax({
+        type:"GET",
+        url:viewsCacheL10n.admin_ajax_url,
+        data:"postviews_id="+viewsCacheL10n.post_id+"&action=postviews",
+        cache:!1,
+        success:function(data) {
+            if(data) {
+                jQuery('#postviews_lscwp').html(data+' views');
+            }
+       }
+    });
+    ```
+
 3. Purge the cache to use the updated pages.
 

--- a/README.md
+++ b/README.md
@@ -266,3 +266,22 @@ N/A
 * You can use: `<?php query_posts( array( 'meta_key' => 'views', 'orderby' => 'meta_value_num', 'order' => 'DESC' ) ); ?>`
 * Or pass in the variables to the URL: `http://yoursite.com/?v_sortby=views&v_orderby=desc`
 * You can replace DESC  with ASC if you want the least viewed posts.
+
+### To Display Updating View Count With LiteSpeed Cache
+1. Use: `<div id="postviews_lscwp"></div>` to replace `<?php if(function_exists('the_views')) { the_views(); } ?>`.
+  * NOTE: The id can be changed, but the div id and the ajax function must match.
+2. Replace the ajax query in `wp-content/plugins/wp-postviews/postviews-cache.js` with
+```
+jQuery.ajax({
+    type:"GET",
+    url:viewsCacheL10n.admin_ajax_url,
+    data:"postviews_id="+viewsCacheL10n.post_id+"&action=postviews",
+    cache:!1,
+    success:function(data) {
+        if(data) {
+            jQuery('#postviews_lscwp').html(data+' views');
+        }
+    }
+});
+```
+3. Purge the cache to use the updated pages.


### PR DESCRIPTION
The FAQ entry mentioned [here](https://wordpress.org/support/topic/compatibility-with-litespeed-cache?replies=1).