### PR TITLE
Remove jQuery and use fetch

### DIFF
--- a/postviews-cache.js
+++ b/postviews-cache.js
@@ -1,1 +1,25 @@
-jQuery.ajax({type:"GET",url:viewsCacheL10n.admin_ajax_url,data:"postviews_id="+viewsCacheL10n.post_id+"&action=postviews",cache:!1});
+fetch( viewsCacheL10n.admin_ajax_url, {
+	method: "POST",
+	credentials: 'same-origin',
+	headers: {
+		'Content-Type': 'application/x-www-form-urlencoded',
+		'Cache-Control': 'no-cache',
+	},
+	body: new URLSearchParams(
+		{
+			action: 'postviews',
+			nonce: viewsCacheL10n.nonce,
+			postviews_id: viewsCacheL10n.post_id,
+			cache: !1,
+		}
+	),
+})
+.then(function(response) {
+	return response.json();
+})
+.then(function(data) {
+})
+.catch(function(error) {
+	console.log('WP-PostViews');
+	console.log(error);
+});

--- a/wp-postviews.php
+++ b/wp-postviews.php
@@ -813,8 +813,7 @@ function increment_views() {
 
 	$post_id = (int) sanitize_key( $_POST['postviews_id'] );
 	if( $post_id > 0 ) {
-		$post_views = get_post_custom( $post_id );
-		$post_views = (int) $post_views['views'][0];
+		$post_views = (int) get_post_meta( $post_id, 'views', true );
 		$post_views = $post_views + 1;
 		update_post_meta( $post_id, 'views', $post_views );
 		do_action( 'postviews_increment_views_ajax', $post_views );


### PR DESCRIPTION
This update removes the jQuery dependency, as well as some small tweaks. The JS is not minified so it's easier to see what's going on. Feel free to tweak and minify.

Here are the changes:

1. Switched to POST instead of GET so we can pass data to `fetch()`.
2. Added `nonce` with a `check_ajax_referer()` check since we're posting data now.
3. Added an additioonal `isset()` check for `postviews_id` in the PHP callback.
4. Switched `get_post_custom()` to `get_post_meta()` because it was throwing an error on old posts that did not have any `views` count saved yet.

This is for https://github.com/lesterchan/wp-postviews/issues/49.