### PR TITLE
Adding WordPress REST API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,7 @@ jQuery.ajax({
 ```
 
 Purge the cache to use the updated pages.
+
+### To Get Views With REST API
+You can obtain the number of post views by adding `views` to your `_fields` parameter:
+`/wp/v2/posts?_fields=views,title`

--- a/wp-postviews.php
+++ b/wp-postviews.php
@@ -1031,3 +1031,18 @@ function views_activation( $network_wide ) {
 function views_options_parse( $key ) {
 	return ! empty( $_POST[ $key ] ) ? $_POST[ $key ] : null;
 }
+
+
+### Function: Register views meta field to use it in REST API
+add_action('rest_api_init', 'register_rest_views_field');
+function register_rest_views_field(){
+	register_rest_field('post', 'views', array(
+		'get_callback' => function ($post) {
+			if (!$post_views = get_post_meta($post['id'], 'views', true)) {
+				$post_views = 0;
+			}
+
+			return (int) $post_views;
+		}
+	));
+}


### PR DESCRIPTION
Add `views` field to REST API response
Example: `/wp/v2/posts?_fields=views,title`